### PR TITLE
Updated cron, ignoring errors

### DIFF
--- a/.github/workflows/create_patch.yml
+++ b/.github/workflows/create_patch.yml
@@ -1,7 +1,7 @@
 name: Create Patch Email
 on:
   schedule:
-    - cron: '30 23 24-31 * 4'
+    - cron: '30 23 29 * *'
   workflow_dispatch:
 
 jobs:
@@ -20,14 +20,15 @@ jobs:
             echo '::set-output name=lastHash::$(git log --since="1 month ago" --format=format:%H -- Dockerfile | tail -1 | cut -c 1-40)'
         id: hash
       - name: Generate patches from that hash
-        run: git format-patch ${{ steps.hash.outputs.lastHash }}~ Dockerfile > patches
+        run: git format-patch ${{ steps.hash.outputs.lastHash }}~ Dockerfile
+        continue-on-error: true
       # There is a PR in the email action to allow globbing that will make this unnecessary once merged
-      - name: Create a one line list of patches to use as attachments
-        run: echo "::set-output name=patches::$(sed -z 's/\n/,/g;s/,$/\n/' patches)"
-        id: patches
+      # - name: Create a one line list of patches to use as attachments
+      #   run: echo "::set-output name=patches::$(sed -z 's/\n/,/g;s/,$/\n/' patches)"
+      #   id: patches
       - name: Send email
-        if: steps.patches.outputs.OUTPUT == 0
-        uses: dawidd6/action-send-mail@v3.2.0
+        # if: steps.patches.outputs.OUTPUT == 0
+        uses: dawidd6/action-send-mail@v3.5.0
         with:
           server_address: smtp.gmail.com
           server_port: 465
@@ -39,4 +40,5 @@ jobs:
           secure: true
           body: See attachment(s)
           ignore_cert: false
-          attachments: ${{ steps.patches.outputs.patches }}
+          attachments: '*.patch'
+          # attachments: ${{ steps.patches.outputs.patches }}


### PR DESCRIPTION
Ignoring errors on generate pataches step to try to keep job from failing if no patches were found.